### PR TITLE
Connection reset

### DIFF
--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -460,7 +460,7 @@ class FortiManager(object):
         while percent != 100:
             try:
                 code, task_info = self.get("/task/task/{taskid}".format(taskid=task_id))
-            except FMGConnectionError:
+            except self.FMGConnectionError:
                 # Set code value to -99 to ensure any future logic is skipped in this failure loop
                 code == -99
                 self.req_resp_object.task_msg = "RemoteDisconnect Issue (FMG BugID: 0703585) occured at " \

--- a/pyFMG/fortimgr.py
+++ b/pyFMG/fortimgr.py
@@ -460,10 +460,10 @@ class FortiManager(object):
         while percent != 100:
             try:
                 code, task_info = self.get("/task/task/{taskid}".format(taskid=task_id))
-            except self.FMGConnectionError:
+            except FMGConnectionError:
                 # Set code value to -99 to ensure any future logic is skipped in this failure loop
                 code == -99
-                self.req_resp_object.task_msg = "RemoteDisconnect Issue (FMG BugID: 0703585) occured at " \
+                self.req_resp_object.error_msg = "RemoteDisconnect Issue (FMG BugID: 0703585) occured at " \
                     "{timestamp}".format(timestamp=datetime.now())
                 self.dprint()
                 code_fail += 1


### PR DESCRIPTION
- Reduced track task timer to 3 seconds by default to alleviate instances of API bug exceptions from occurring
- Added connection reset code and config options to address a TCP reset from the FMG due to Bug ID: 0703585 introduced FMG version > 6.4.4.  Config option is set to FALSE by default so no impact to existing code is expected and interaction with that bug